### PR TITLE
GTF_extract: fix broken -o option

### DIFF
--- a/GFFUtils/GTF_extract.py
+++ b/GFFUtils/GTF_extract.py
@@ -106,7 +106,7 @@ def main():
             if feature_type is None or line['feature'] == feature_type:
                 # Extract and report data
                 if field_list is None:
-                    print "%s" % line
+                    fp.write("%s\n" % line)
                 else:
                     out_line = []
                     for field in field_list:


### PR DESCRIPTION
PR to fix the broken `-o` option of `GTF_extract` as reported in issue #2. Without the fix the output was being written to screen unless the `--fields` option was also specified.