### PR TITLE
Add required Python versions to 'setup.py'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     install_requires = ['genomics-bcftbx'],
     test_suite = 'nose.collector',
     tests_require = ['nose'],
+    python_requires = '>=2.6, <3',
     include_package_data=True,
     zip_safe = False
 )


### PR DESCRIPTION
PR which goes towards addressing issue #3, by specifying the required Python versions via the `python_requires` keyword:

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

Note that this needs recent versions of `pip` and `setuptools` to work, so is not the complete solution.