### PR TITLE
Update installation docs to specify Python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ Installation
 
 It is recommended to use::
 
-    pip install -r requirements.txt
-    pip install .
+    pip2 install -r requirements.txt
+    pip2 install .
 
 from within the top-level source directory to install the package.
 
@@ -26,12 +26,15 @@ directory to your ``PYTHONPATH`` environment.
 
 To install directly from github using ``pip``::
 
-    pip install -r https://raw.githubusercontent.com/fls-bioinformatics-core/GFFUtils/master/requirements.txt
-    pip install git+https://github.com/fls-bioinformatics-core/GFFUtils.git
+    pip2 install -r https://raw.githubusercontent.com/fls-bioinformatics-core/GFFUtils/master/requirements.txt
+    pip2 install git+https://github.com/fls-bioinformatics-core/GFFUtils.git
 
 (In either of these latter two cases you will also need to install the
 ``genomics-bcftbx`` package from
 https://github.com/fls-bioinformatics-core/genomics)
+
+Note that ``GFFUtils`` requires Python 2 and doesn't currently work with
+Python 3.
 
 Documentation
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,9 +18,13 @@ Installation
 
 To install from github, do::
 
-    pip install -r https://raw.githubusercontent.com/fls-bioinformatics-core/GFFUtils/refactor/requirements.txt
-    pip install git+https://github.com/fls-bioinformatics-core/GFFUtils.git
+    pip2 install -r https://raw.githubusercontent.com/fls-bioinformatics-core/GFFUtils/refactor/requirements.txt
+    pip2 install git+https://github.com/fls-bioinformatics-core/GFFUtils.git
 
+.. note::
+
+   ``GFFUtils`` requires Python 2 and doesn't currently work with
+   Python 3.
 
 Contents
 ********


### PR DESCRIPTION
PR which addresses issue raised in #3, by explicitly stating the required Python version in the `README` and the Sphinx docs (and that installation should use `pip2`).