### PR TITLE
GFFcleaner: fix bug when using '--clean' on GFF with missing 'SGD' attributes

### DIFF
--- a/GFFUtils/GFFcleaner.py
+++ b/GFFUtils/GFFcleaner.py
@@ -125,7 +125,9 @@ def GFFUpdateAttributes(gff_data,update_keys={},exclude_keys=[],no_empty_values=
                     else:
                         attributes[key] = new_value
                 except KeyError:
-                    logging.warning("No value for '%s' ('%s')" % (lookup_key,key))
+                    logging.warning("Cannot update value of attribute '%s': "
+                                    "replacement attribute '%s' not found" %
+                                    (key,lookup_key))
             except KeyError:
                 # No mapping found for key, ignore
                 pass

--- a/GFFUtils/GFFcleaner.py
+++ b/GFFUtils/GFFcleaner.py
@@ -354,7 +354,11 @@ def GFFGroupSGDs(gff_data):
         # Process the attributes data
         attributes = data['attributes']
         # Get the SGD value
-        sgd = attributes['SGD']
+        try:
+            sgd = attributes['SGD']
+        except KeyError:
+            # SGD not in the attributes, treat as blank
+            sgd = ''
         if sgd != '':
             # Check the ID
             idx = GFFID(attributes['ID'])


### PR DESCRIPTION
PR which implements a fix for the second bug reported in issue #10, when `GFFcleaner` is run with the `--clean` option on a GFF where the attributes don't include `SGD` values.

The fix now treats the case of missing `SGD` values the same as when the `SGD` values are present, but blank.