### PR TITLE
setup.py: update supported Python versions to 2.7 and above.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ Installation
 
 It is recommended to use::
 
-    pip2 install -r requirements.txt
-    pip2 install .
+    pip install -r requirements.txt
+    pip install .
 
 from within the top-level source directory to install the package.
 
@@ -26,15 +26,20 @@ directory to your ``PYTHONPATH`` environment.
 
 To install directly from github using ``pip``::
 
-    pip2 install -r https://raw.githubusercontent.com/fls-bioinformatics-core/GFFUtils/master/requirements.txt
-    pip2 install git+https://github.com/fls-bioinformatics-core/GFFUtils.git
+    pip install -r https://raw.githubusercontent.com/fls-bioinformatics-core/GFFUtils/master/requirements.txt
+    pip install git+https://github.com/fls-bioinformatics-core/GFFUtils.git
 
 (In either of these latter two cases you will also need to install the
 ``genomics-bcftbx`` package from
 https://github.com/fls-bioinformatics-core/genomics)
 
-Note that ``GFFUtils`` requires Python 2 and doesn't currently work with
-Python 3.
+Note that ``GFFUtils`` is currently supported for the following Python
+versions:
+
+* 2.7
+* 3.7
+
+but support for Python 2.7 is likely to be dropped in the near future.
 
 Documentation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -78,5 +78,5 @@ Credits
 
 These utilities have been developed by Peter Briggs with input from
 Leo Zeef, to support the activities of the Bioinformatics Core Facility
-(BCF) in the Faculty of Life Sciences (FLS) at the University of
-Manchester (UoM).
+(BCF) in the Faculty of Biology Medicine and Health (FBMH) at the
+University of Manchester (UoM).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,13 +18,19 @@ Installation
 
 To install from github, do::
 
-    pip2 install -r https://raw.githubusercontent.com/fls-bioinformatics-core/GFFUtils/master/requirements.txt
-    pip2 install git+https://github.com/fls-bioinformatics-core/GFFUtils.git
+    pip install -r https://raw.githubusercontent.com/fls-bioinformatics-core/GFFUtils/master/requirements.txt
+    pip install git+https://github.com/fls-bioinformatics-core/GFFUtils.git
 
 .. note::
 
-   ``GFFUtils`` requires Python 2 and doesn't currently work with
-   Python 3.
+   ``GFFUtils`` is currently supported for the following Python
+   versions:
+
+   * 2.7
+   * 3.7
+
+   but support for Python 2.7 is likely to be dropped in the near
+   future.
 
 Contents
 ********

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,8 +56,8 @@ Credits
 
 These utilities have been developed by Peter Briggs with input from
 Leo Zeef, to support the activities of the Bioinformatics Core Facility
-(BCF) in the Faculty of Life Sciences (FLS) at the University of
-Manchester (UoM).
+(BCF) in the Faculty of Biology Medicine and Health (FBMH) at the
+University of Manchester (UoM).
 
 
 Indices and tables

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ Description
 Setup script to install GFFUtils: utilities for working with
 GFF and GTF files
 
-Copyright (C) University of Manchester 2011-2015 Peter Briggs
+Copyright (C) University of Manchester 2011-2015,2020 Peter Briggs
 
 """
 
@@ -32,7 +32,7 @@ setup(
     install_requires = ['genomics-bcftbx'],
     test_suite = 'nose.collector',
     tests_require = ['nose'],
-    python_requires = '>=2.6, <3',
+    python_requires = '>=2.7',
     include_package_data=True,
     zip_safe = False
 )


### PR DESCRIPTION
PR which drops support for Python 2.6 and allows `GFFUtils` to be installed against Python 3.*.