### PR TITLE
Remove import of StringIO from cStringIO module for Python 3 compatibility

### DIFF
--- a/test/test_GFFFile.py
+++ b/test/test_GFFFile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import unittest
-import cStringIO
+from io import StringIO
 from GFFUtils.GFFFile import *
 
 class TestGFFIterator(unittest.TestCase):
@@ -10,7 +10,7 @@ class TestGFFIterator(unittest.TestCase):
 
     def setUp(self):
         # Example GFF file fragment
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """##gff-version 3
 # generated: Wed Feb 21 12:01:58 2012
 DDB0123458	Sequencing Center	chromosome	1	4923596	.	+	.	ID=DDB0232428;Name=1
@@ -49,7 +49,7 @@ class TestGFFFile(unittest.TestCase):
 
     def setUp(self):
         # Example GFF file fragment
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """##gff-version 3
 # generated: Wed Feb 21 12:01:58 2012
 DDB0123458	Sequencing Center	chromosome	1	4923596	.	+	.	ID=DDB0232428;Name=1

--- a/test/test_GFFFile.py
+++ b/test/test_GFFFile.py
@@ -11,7 +11,7 @@ class TestGFFIterator(unittest.TestCase):
     def setUp(self):
         # Example GFF file fragment
         self.fp = StringIO(
-"""##gff-version 3
+u"""##gff-version 3
 # generated: Wed Feb 21 12:01:58 2012
 DDB0123458	Sequencing Center	chromosome	1	4923596	.	+	.	ID=DDB0232428;Name=1
 DDB0232428	Sequencing Center	contig	101	174493	.	+	.	ID=DDB0232440;Parent=DDB0232428;Name=DDB0232440;description=Contig generated from contig finding genome version 2.5;Dbxref=Contig GI Number:90970918,Accession Number:AAFI02000001,SeqID for Genbank:DDB0232440.02
@@ -50,7 +50,7 @@ class TestGFFFile(unittest.TestCase):
     def setUp(self):
         # Example GFF file fragment
         self.fp = StringIO(
-"""##gff-version 3
+u"""##gff-version 3
 # generated: Wed Feb 21 12:01:58 2012
 DDB0123458	Sequencing Center	chromosome	1	4923596	.	+	.	ID=DDB0232428;Name=1
 DDB0232428	Sequencing Center	contig	101	174493	.	+	.	ID=DDB0232440;Parent=DDB0232428;Name=DDB0232440;description=Contig generated from contig finding genome version 2.5;Dbxref=Contig GI Number:90970918,Accession Number:AAFI02000001,SeqID for Genbank:DDB0232440.02

--- a/test/test_GFFcleaner.py
+++ b/test/test_GFFcleaner.py
@@ -9,7 +9,7 @@ class TestGroupGeneSubsets(unittest.TestCase):
     def setUp(self):
         # List of genes to group
         self.fp = StringIO(
-"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=CDS:YEL0W01:1;SGD=YEL0W01
+u"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=CDS:YEL0W01:1;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=CDS:YEL0W02:1;SGD=YEL0W02
 chr1\tTest\tCDS\t32611\t34140\t0\t-\t0\tID=CDS:YEL0W02:2;SGD=YEL0W02
 chr1\tTest\tCDS\t34525\t35262\t0\t-\t0\tID=CDS:YEL0W03:1;SGD=YEL0W03
@@ -32,10 +32,10 @@ class TestGFFUpdateAttributes(unittest.TestCase):
     def setUp(self):
         # Make file-like object to read data in
         self.fp = StringIO(
-"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=abc;kaks=-le+100;SGD=YEL0W;ncbi=-1e+100;Name=def;
+u"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=abc;kaks=-le+100;SGD=YEL0W;ncbi=-1e+100;Name=def;
 """)
         self.fp2 = StringIO(
-"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=abc;kaks=-le+100;SGD=YEL0W;ncbi=-1e+100;Name=def;123-234;456-567;
+u"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=abc;kaks=-le+100;SGD=YEL0W;ncbi=-1e+100;Name=def;123-234;456-567;
 """)
 
     def test_update_attributes_exclude_keys(self):
@@ -84,7 +84,7 @@ class TestGFFGetDuplicateSGDs(unittest.TestCase):
     def setUp(self):
         # Make file-like object to read data in
         self.fp = StringIO(
-"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=YEL0W01;SGD=YEL0W01
+u"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=YEL0W01;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=YEL0W02;SGD=YEL0W02
 chr1\tTest\tCDS\t32611\t34140\t0\t-\t0\tID=YEL0W02;SGD=YEL0W02
 chr1\tTest\tCDS\t34525\t35262\t0\t-\t0\tID=YEL0W03;SGD=YEL0W03
@@ -119,7 +119,7 @@ class TestGFFResolveDuplicateSGDs(unittest.TestCase):
         # - unrelated duplicates in different chromosomes (YEL0W2)
         # - grouped duplicated in same chromosome (YEL0W03)
         self.fp = StringIO(
-"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=CDS:YEL0W01:1;SGD=YEL0W01
+u"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=CDS:YEL0W01:1;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=CDS:YEL0W02:1;SGD=YEL0W02
 chr1\tTest\tCDS\t32611\t34140\t0\t-\t0\tID=CDS:YEL0W02:2;SGD=YEL0W02
 chr1\tTest\tCDS\t34525\t35262\t0\t-\t0\tID=CDS:YEL0W03:1;SGD=YEL0W03
@@ -131,31 +131,31 @@ chr2\tTest\tCDS\t41402\t41831\t0\t+\t0\tID=CDS:YEL0W05:1;SGD=YEL0W05
 """)
         # Mapping data to resolve all duplicates
         self.mp_resolve_all = StringIO(
-"""YEL0W01\tchr1\t39195\t39569\t-
+u"""YEL0W01\tchr1\t39195\t39569\t-
 YEL0W03\tchr1\t34525\t37004\t-
 YEL0W02\tchr2\t40406\t40864\t-
 """)
         # Mapping data with a mapping gene removed
         self.mp_missing_mapping_gene = StringIO(
-"""YEL0W01\tchr1\t39195\t39569\t-
+u"""YEL0W01\tchr1\t39195\t39569\t-
 YEL0W03\tchr1\t34525\t37004\t-
 """)
         # Mapping data with a mapping gene that doesn't match
         # on strand for one duplicate
         self.mp_missing_matching_mapping_gene = StringIO(
-"""YEL0W01\tchr1\t39195\t39569\t-
+u"""YEL0W01\tchr1\t39195\t39569\t-
 YEL0W03\tchr1\t34525\t37004\t+
 YEL0W02\tchr2\t40406\t40864\t-
 """)
         # Mapping data with a mapping gene that doesn't overlap
         self.mp_mapping_gene_no_overlap = StringIO(
-"""YEL0W03\tchr1\t34525\t37004\t-
+u"""YEL0W03\tchr1\t34525\t37004\t-
 YEL0W01\tchr1\t41402\t41831\t-
 YEL0W02\tchr2\t40406\t40864\t-
 """)
         # Mapping data with multiple mapping genes with same name
         self.mp_multiple_mapping_genes = StringIO(
-"""YEL0W01\tchr1\t28789\t29049\t-
+u"""YEL0W01\tchr1\t28789\t29049\t-
 YEL0W03\tchr1\t34525\t37004\t-
 YEL0W01\tchr1\t39195\t39569\t-
 YEL0W02\tchr2\t40406\t40864\t-
@@ -341,7 +341,7 @@ class TestGFFGroupSGDs(unittest.TestCase):
     def setUp(self):
         # Make file-like object to read data in
         self.fp = StringIO(
-"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=YEL0W01;SGD=YEL0W01
+u"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=YEL0W01;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=YEL0W02;SGD=YEL0W02
 chr1\tTest\tCDS\t32611\t34140\t0\t-\t0\tID=YEL0W02;SGD=YEL0W02
 chr1\tTest\tCDS\t34525\t35262\t0\t-\t0\tID=YEL0W03;SGD=YEL0W03
@@ -376,7 +376,7 @@ class TestGFFInsertMissingGenes(unittest.TestCase):
     def setUp(self):
         # Make file-like object for GFF data
         self.fp = StringIO(
-"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=CDS:YEL0W01:1;SGD=YEL0W01
+u"""chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=CDS:YEL0W01:1;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=CDS:YEL0W02:1;SGD=YEL0W02
 chr1\tTest\tCDS\t34525\t35262\t0\t-\t0\tID=CDS:YEL0W04:1;SGD=YEL0W04
 chr1\tTest\tCDS\t35823\t37004\t0\t-\t0\tID=CDS:YEL0W04:2;SGD=YEL0W04
@@ -386,7 +386,7 @@ chr2\tTest\tCDS\t40406\t40864\t0\t-\t0\tID=CDS:YEL0W06:2;SGD=YEL0W06
 """)
         # Make a file-like object for mapping data
         self.mp = StringIO(
-"""YEL0W03\tchr1\t32611\t34140\t-
+u"""YEL0W03\tchr1\t32611\t34140\t-
 YEL0W06\tchr2\t49195\t49569\t-
 """
 )
@@ -416,7 +416,7 @@ class TestGFFAddExonIDs(unittest.TestCase):
     def setUp(self):
         # Make file-like object for GFF pseudo-data
         self.fp = StringIO(
-"""chr1\tTest\texon\t1890\t3287\t.\t+\t.\tParent=DDB0216437
+u"""chr1\tTest\texon\t1890\t3287\t.\t+\t.\tParent=DDB0216437
 chr1\tTest\texon\t3848\t4855\t.\t+\t.\tParent=DDB0216438
 chr1\tTest\tCDS\t5505\t7769\t.\t+\t.\tParent=DDB0216439
 chr1\tTest\tCDS\t8308\t9522\t.\t-\t.\tParent=DDB0216440
@@ -446,7 +446,7 @@ class TestGFFAddIDAttributes(unittest.TestCase):
     def setUp(self):
         # Make file-like object for GFF pseudo-data
         self.fp = StringIO(
-"""chr1\tTest\texon\t1890\t3287\t.\t+\t.\tParent=DDB0216437
+u"""chr1\tTest\texon\t1890\t3287\t.\t+\t.\tParent=DDB0216437
 chr1\tTest\texon\t3848\t4855\t.\t+\t.\tParent=DDB0216438
 chr1\tTest\tCDS\t5505\t7769\t.\t+\t.\tParent=DDB0216439
 chr1\tTest\tCDS\t8308\t9522\t.\t-\t.\tParent=DDB0216440
@@ -475,7 +475,7 @@ class TestGFFDecodeAttributes(unittest.TestCase):
     def setUp(self):
         # Make file-like object for GFF pseudo-data
         self.fp = StringIO(
-"""chr1\t.\tgene\t5505\t7769\t.\t+\t.\tID=DDB_G0267182;Name=DDB_G0123456;description=ORF2 protein fragment of DIRS1 retrotransposon%3B refer to Genbank M11339 for full-length element
+u"""chr1\t.\tgene\t5505\t7769\t.\t+\t.\tID=DDB_G0267182;Name=DDB_G0123456;description=ORF2 protein fragment of DIRS1 retrotransposon%3B refer to Genbank M11339 for full-length element
 chr1\t.\tgene\t21490\t23468\t.\t+\t.\tID=DDB_G0267204;Name=DDB_G0123456;description=putative pseudogene%3B similar to a family of genes%2C including %3Ca href%3D%22%2Fgene%2FDDB_G0267252%22%3EDDB_G0267252%3C%2Fa%3E
 """)
 

--- a/test/test_GFFcleaner.py
+++ b/test/test_GFFcleaner.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
 import unittest
-import cStringIO
+from io import StringIO
 from GFFUtils.GFFcleaner import *
 
 class TestGroupGeneSubsets(unittest.TestCase):
 
     def setUp(self):
         # List of genes to group
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=CDS:YEL0W01:1;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=CDS:YEL0W02:1;SGD=YEL0W02
 chr1\tTest\tCDS\t32611\t34140\t0\t-\t0\tID=CDS:YEL0W02:2;SGD=YEL0W02
@@ -31,10 +31,10 @@ class TestGFFUpdateAttributes(unittest.TestCase):
 
     def setUp(self):
         # Make file-like object to read data in
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=abc;kaks=-le+100;SGD=YEL0W;ncbi=-1e+100;Name=def;
 """)
-        self.fp2 = cStringIO.StringIO(
+        self.fp2 = StringIO(
 """chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=abc;kaks=-le+100;SGD=YEL0W;ncbi=-1e+100;Name=def;123-234;456-567;
 """)
 
@@ -83,7 +83,7 @@ class TestGFFGetDuplicateSGDs(unittest.TestCase):
 
     def setUp(self):
         # Make file-like object to read data in
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=YEL0W01;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=YEL0W02;SGD=YEL0W02
 chr1\tTest\tCDS\t32611\t34140\t0\t-\t0\tID=YEL0W02;SGD=YEL0W02
@@ -118,7 +118,7 @@ class TestGFFResolveDuplicateSGDs(unittest.TestCase):
         # - unrelated duplicates in same chromosome (YEL0W01)
         # - unrelated duplicates in different chromosomes (YEL0W2)
         # - grouped duplicated in same chromosome (YEL0W03)
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=CDS:YEL0W01:1;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=CDS:YEL0W02:1;SGD=YEL0W02
 chr1\tTest\tCDS\t32611\t34140\t0\t-\t0\tID=CDS:YEL0W02:2;SGD=YEL0W02
@@ -130,31 +130,31 @@ chr2\tTest\tCDS\t40406\t40864\t0\t-\t0\tID=CDS:YEL0W02:1;SGD=YEL0W02
 chr2\tTest\tCDS\t41402\t41831\t0\t+\t0\tID=CDS:YEL0W05:1;SGD=YEL0W05
 """)
         # Mapping data to resolve all duplicates
-        self.mp_resolve_all = cStringIO.StringIO(
+        self.mp_resolve_all = StringIO(
 """YEL0W01\tchr1\t39195\t39569\t-
 YEL0W03\tchr1\t34525\t37004\t-
 YEL0W02\tchr2\t40406\t40864\t-
 """)
         # Mapping data with a mapping gene removed
-        self.mp_missing_mapping_gene = cStringIO.StringIO(
+        self.mp_missing_mapping_gene = StringIO(
 """YEL0W01\tchr1\t39195\t39569\t-
 YEL0W03\tchr1\t34525\t37004\t-
 """)
         # Mapping data with a mapping gene that doesn't match
         # on strand for one duplicate
-        self.mp_missing_matching_mapping_gene = cStringIO.StringIO(
+        self.mp_missing_matching_mapping_gene = StringIO(
 """YEL0W01\tchr1\t39195\t39569\t-
 YEL0W03\tchr1\t34525\t37004\t+
 YEL0W02\tchr2\t40406\t40864\t-
 """)
         # Mapping data with a mapping gene that doesn't overlap
-        self.mp_mapping_gene_no_overlap = cStringIO.StringIO(
+        self.mp_mapping_gene_no_overlap = StringIO(
 """YEL0W03\tchr1\t34525\t37004\t-
 YEL0W01\tchr1\t41402\t41831\t-
 YEL0W02\tchr2\t40406\t40864\t-
 """)
         # Mapping data with multiple mapping genes with same name
-        self.mp_multiple_mapping_genes = cStringIO.StringIO(
+        self.mp_multiple_mapping_genes = StringIO(
 """YEL0W01\tchr1\t28789\t29049\t-
 YEL0W03\tchr1\t34525\t37004\t-
 YEL0W01\tchr1\t39195\t39569\t-
@@ -340,7 +340,7 @@ class TestGFFGroupSGDs(unittest.TestCase):
 
     def setUp(self):
         # Make file-like object to read data in
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=YEL0W01;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=YEL0W02;SGD=YEL0W02
 chr1\tTest\tCDS\t32611\t34140\t0\t-\t0\tID=YEL0W02;SGD=YEL0W02
@@ -375,7 +375,7 @@ class TestGFFInsertMissingGenes(unittest.TestCase):
 
     def setUp(self):
         # Make file-like object for GFF data
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """chr1\tTest\tCDS\t28789\t29049\t0\t-\t0\tID=CDS:YEL0W01:1;SGD=YEL0W01
 chr1\tTest\tCDS\t29963\t32155\t0\t-\t0\tID=CDS:YEL0W02:1;SGD=YEL0W02
 chr1\tTest\tCDS\t34525\t35262\t0\t-\t0\tID=CDS:YEL0W04:1;SGD=YEL0W04
@@ -385,7 +385,7 @@ chr2\tTest\tCDS\t39195\t39569\t0\t-\t0\tID=CDS:YEL0W06:1;SGD=YEL0W06
 chr2\tTest\tCDS\t40406\t40864\t0\t-\t0\tID=CDS:YEL0W06:2;SGD=YEL0W06
 """)
         # Make a file-like object for mapping data
-        self.mp = cStringIO.StringIO(
+        self.mp = StringIO(
 """YEL0W03\tchr1\t32611\t34140\t-
 YEL0W06\tchr2\t49195\t49569\t-
 """
@@ -415,7 +415,7 @@ class TestGFFAddExonIDs(unittest.TestCase):
 
     def setUp(self):
         # Make file-like object for GFF pseudo-data
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """chr1\tTest\texon\t1890\t3287\t.\t+\t.\tParent=DDB0216437
 chr1\tTest\texon\t3848\t4855\t.\t+\t.\tParent=DDB0216438
 chr1\tTest\tCDS\t5505\t7769\t.\t+\t.\tParent=DDB0216439
@@ -445,7 +445,7 @@ class TestGFFAddIDAttributes(unittest.TestCase):
 
     def setUp(self):
         # Make file-like object for GFF pseudo-data
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """chr1\tTest\texon\t1890\t3287\t.\t+\t.\tParent=DDB0216437
 chr1\tTest\texon\t3848\t4855\t.\t+\t.\tParent=DDB0216438
 chr1\tTest\tCDS\t5505\t7769\t.\t+\t.\tParent=DDB0216439
@@ -474,7 +474,7 @@ class TestGFFDecodeAttributes(unittest.TestCase):
 
     def setUp(self):
         # Make file-like object for GFF pseudo-data
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """chr1\t.\tgene\t5505\t7769\t.\t+\t.\tID=DDB_G0267182;Name=DDB_G0123456;description=ORF2 protein fragment of DIRS1 retrotransposon%3B refer to Genbank M11339 for full-length element
 chr1\t.\tgene\t21490\t23468\t.\t+\t.\tID=DDB_G0267204;Name=DDB_G0123456;description=putative pseudogene%3B similar to a family of genes%2C including %3Ca href%3D%22%2Fgene%2FDDB_G0267252%22%3EDDB_G0267252%3C%2Fa%3E
 """)

--- a/test/test_GTFFile.py
+++ b/test/test_GTFFile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import unittest
-import cStringIO
+from io import StringIO
 from GFFUtils.GTFFile import *
 
 class TestGTFDataLine(unittest.TestCase):
@@ -80,7 +80,7 @@ class TestGTFIterator(unittest.TestCase):
 
     def setUp(self):
         # Example GTF file fragment
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """##description: evidence-based annotation of the human genome (GRCh37), version 19 (Ensembl 74)
 ##provider: GENCODE
 ##contact: gencode@sanger.ac.uk
@@ -122,7 +122,7 @@ class TestGTFFile(unittest.TestCase):
 
     def setUp(self):
         # Example GTF file fragment
-        self.fp = cStringIO.StringIO(
+        self.fp = StringIO(
 """##description: evidence-based annotation of the human genome (GRCh37), version 19 (Ensembl 74)
 ##provider: GENCODE
 ##contact: gencode@sanger.ac.uk

--- a/test/test_GTFFile.py
+++ b/test/test_GTFFile.py
@@ -81,7 +81,7 @@ class TestGTFIterator(unittest.TestCase):
     def setUp(self):
         # Example GTF file fragment
         self.fp = StringIO(
-"""##description: evidence-based annotation of the human genome (GRCh37), version 19 (Ensembl 74)
+u"""##description: evidence-based annotation of the human genome (GRCh37), version 19 (Ensembl 74)
 ##provider: GENCODE
 ##contact: gencode@sanger.ac.uk
 ##format: gtf
@@ -123,7 +123,7 @@ class TestGTFFile(unittest.TestCase):
     def setUp(self):
         # Example GTF file fragment
         self.fp = StringIO(
-"""##description: evidence-based annotation of the human genome (GRCh37), version 19 (Ensembl 74)
+u"""##description: evidence-based annotation of the human genome (GRCh37), version 19 (Ensembl 74)
 ##provider: GENCODE
 ##contact: gencode@sanger.ac.uk
 ##format: gtf


### PR DESCRIPTION
PR which imports the `StringIO` class from `io` rather than `cStringIO` in the unit tests, for compatibility with Python 3.