### PR TITLE
Classes should inherit from 'object'

### DIFF
--- a/GFFUtils/GFF3_Annotation_Extractor.py
+++ b/GFFUtils/GFF3_Annotation_Extractor.py
@@ -66,7 +66,7 @@ import glob
 # Class definitions
 #######################################################################
 
-class GFFAnnotationLookup:
+class GFFAnnotationLookup(object):
     """Utility class for acquiring parent gene names and data
 
     The GFFAnnotationLookup class provides functionality for indexing
@@ -244,7 +244,7 @@ class GFFAnnotationLookup:
         # Done
         return annotation
 
-class GFFAnnotation:
+class GFFAnnotation(object):
     """Container class for GFF annotation data
 
     Once instantiated the calling subprogram should populate the
@@ -266,7 +266,7 @@ class GFFAnnotation:
         self.end = ''
         self.gene_length = ''
 
-class HTSeqCountFile:
+class HTSeqCountFile(object):
     """Class for handling data from output of htseq-count program
 
     The htseq-count program outputs 2-columns of tab-delimited data,

--- a/GFFUtils/GFFFile.py
+++ b/GFFUtils/GFFFile.py
@@ -203,7 +203,7 @@ class GFFFile(TabFile):
         """
         return self._version
 
-class OrderedDictionary:
+class OrderedDictionary(object):
     """Augumented dictionary which keeps keys in order
 
     OrderedDictionary provides an augmented Python dictionary
@@ -404,7 +404,7 @@ class GFFAttributes(OrderedDictionary):
             items.append('')
         return ';'.join(items)
 
-class GFFID:
+class GFFID(object):
     """Class for handling ID attribute in GFF data
 
     The GFFID class takes an ID string which is expected to be of

--- a/GFFUtils/GTFFile.py
+++ b/GFFUtils/GTFFile.py
@@ -99,7 +99,7 @@ class GTFDataLine(GFFFile.GFFDataLine):
                                      lineno=lineno,delimiter=delimiter,gff_line_type=gff_line_type)
         self['attributes'] = GTFAttributes(str(self['attributes']))
 
-class GTFAttributes:
+class GTFAttributes(object):
     """Class for handling GTF 'attribute' data
 
     The GTF 'attribute' data consists of semi-colon separated


### PR DESCRIPTION
PR which updates the class definitions so that all classes inherit from an explicit superclass, which defaults to `object`.