### PR TITLE
GTFFile: add __repr__ built-in to GTFAttributes class

### DIFF
--- a/GFFUtils/GTFFile.py
+++ b/GFFUtils/GTFFile.py
@@ -114,9 +114,16 @@ class GTFAttributes(object):
     """
     def __init__(self,attribute_data=None):
         self.__attributes = OrderedDictionary()
+        self.__quotes = dict()
         for attr in GFFAttributes(attribute_data=attribute_data).nokeys():
             key = attr.split(' ')[0]
-            self.__attributes[key] = ' '.join(attr.split(' ')[1:]).strip('"')
+            value = ' '.join(attr.split(' ')[1:])
+            if value.startswith('"') and value.endswith('"'):
+                # Store quotation style for quoted values
+                self.__quotes[key] = '"'
+                value = value[1:-1]
+            self.__attributes[key] = value
+
     def __getitem__(self,name):
         try:
             return self.__attributes[name]
@@ -126,6 +133,19 @@ class GTFAttributes(object):
         return self[name] is not None
     def __iter__(self):
         return iter(self.__attributes.keys())
+    def __repr__(self):
+        # Reconstruct and return the original attribute string
+        attributes = list()
+        for key in self:
+            try:
+                quotes = self.__quotes[key]
+            except KeyError:
+                quotes = ''
+            attributes.append("%s %s%s%s;" % (key,
+                                              quotes,
+                                              self[key],
+                                              quotes))
+        return ' '.join(attributes)
 
 class GTFFile(GFFFile):
     """Class for handling GTF files in-memory

--- a/test/test_GTFFile.py
+++ b/test/test_GTFFile.py
@@ -34,6 +34,8 @@ class TestGTFDataLine(unittest.TestCase):
         self.assertEqual("2",line['attributes']['level'])
         self.assertEqual("OTTHUMG00000000961.2",line['attributes']['havana_gene'])
         self.assertEqual(None,line['attributes']['missing'])
+        # Check we get back original representation
+        self.assertEqual(self.gtf_line,str(line))
 
 class TestGTFAttributes(unittest.TestCase):
 
@@ -74,6 +76,13 @@ class TestGTFAttributes(unittest.TestCase):
         line = GTFDataLine(self.gtf_line)
         for attr in line['attributes']:
             self.assertNotEqual(line['attributes'][attr],None)
+
+    def test_recover_representation(self):
+        """Test that __repr__ returns original string
+        """
+        attributes = """gene_id "ENSG00000223972.4"; transcript_id "ENSG00000223972.4"; gene_type "pseudogene"; gene_status "KNOWN"; gene_name "DDX11L1"; transcript_type "pseudogene"; transcript_status "KNOWN"; transcript_name "DDX11L1"; level 2; havana_gene "OTTHUMG00000000961.2";"""
+        attr = GTFAttributes(attributes)
+        self.assertEqual(attributes,str(attr))
 
 class TestGTFIterator(unittest.TestCase):
     """Basic tests for iterating through a GTF file


### PR DESCRIPTION
PR which implements the `__repr__` built-in for the `GTFAttributes` class, so that the data can be output to a string in the correct format.

(Note that this also fixes a bug in the `gtf2bed` utility.)