### PR TITLE
GTFFile: update 'GTFAttributes' to handle attributes which appear multiple times

### DIFF
--- a/GFFUtils/GTFFile.py
+++ b/GFFUtils/GTFFile.py
@@ -122,7 +122,14 @@ class GTFAttributes(object):
                 # Store quotation style for quoted values
                 self.__quotes[key] = '"'
                 value = value[1:-1]
-            self.__attributes[key] = value
+            if key not in self:
+                # New attribute
+                self.__attributes[key] = value
+            else:
+                # Attribute with multiple values
+                if not isinstance(self.__attributes[key],list):
+                    self.__attributes[key] = [self.__attributes[key]]
+                self.__attributes[key].append(value)
 
     def __getitem__(self,name):
         try:
@@ -141,10 +148,15 @@ class GTFAttributes(object):
                 quotes = self.__quotes[key]
             except KeyError:
                 quotes = ''
-            attributes.append("%s %s%s%s;" % (key,
-                                              quotes,
-                                              self[key],
-                                              quotes))
+            if not isinstance(self[key],list):
+                values = [self[key]]
+            else:
+                values = self[key]
+            for value in values:
+                attributes.append("%s %s%s%s;" % (key,
+                                                  quotes,
+                                                  value,
+                                                  quotes))
         return ' '.join(attributes)
 
 class GTFFile(GFFFile):

--- a/test/test_GTFFile.py
+++ b/test/test_GTFFile.py
@@ -84,6 +84,27 @@ class TestGTFAttributes(unittest.TestCase):
         attr = GTFAttributes(attributes)
         self.assertEqual(attributes,str(attr))
 
+    def test_gtf_attributes_multiple_tags(self):
+        attributes = """gene_id "ENSMUSG00000000028"; transcript_id "ENSMUST00000115585"; exon_number "5"; gene_name "Cdc45"; gene_source "ensembl_havana"; gene_biotype "protein_coding"; transcript_name "Cdc45-002"; transcript_source "havana"; exon_id "ENSMUSE00000703491"; tag "cds_end_NF"; tag "mRNA_end_NF";"""
+        attr = GTFAttributes(attributes)
+        self.assertEqual(attr['gene_id'],'ENSMUSG00000000028')
+        self.assertEqual(attr['transcript_id'],'ENSMUST00000115585')
+        self.assertEqual(attr['exon_number'],'5')
+        self.assertEqual(attr['gene_name'],'Cdc45')
+        self.assertEqual(attr['gene_source'],'ensembl_havana')
+        self.assertEqual(attr['gene_biotype'],'protein_coding')
+        self.assertEqual(attr['transcript_name'],'Cdc45-002')
+        self.assertEqual(attr['transcript_source'],'havana')
+        self.assertEqual(attr['exon_id'],'ENSMUSE00000703491')
+        self.assertEqual(attr['tag'],['cds_end_NF','mRNA_end_NF'])
+
+    def test_recover_representation_multiple_tags(self):
+        """Test that __repr__ returns original string
+        """
+        attributes = """gene_id "ENSMUSG00000000028"; transcript_id "ENSMUST00000115585"; exon_number "5"; gene_name "Cdc45"; gene_source "ensembl_havana"; gene_biotype "protein_coding"; transcript_name "Cdc45-002"; transcript_source "havana"; exon_id "ENSMUSE00000703491"; tag "cds_end_NF"; tag "mRNA_end_NF";"""
+        attr = GTFAttributes(attributes)
+        self.assertEqual(attributes,str(attr))
+
 class TestGTFIterator(unittest.TestCase):
     """Basic tests for iterating through a GTF file
     """


### PR DESCRIPTION
PR which fixes the `GTFAttributes` class to handle attributes which appear multiple times, for example:

    gene_id "ENSMUSG00000000037"; transcript_id "ENSMUST00000101113"; ...; tag "cds_end_NF"; tag "cds_start_NF"; tag "mRNA_end_NF"; tag "mRNA_start_NF";

has multiple `tag` attributes.