### PR TITLE
gtf2bed: fix relative imports for Python 3 compatibility

### DIFF
--- a/GFFUtils/gtf2bed.py
+++ b/GFFUtils/gtf2bed.py
@@ -5,8 +5,8 @@
 #
 import sys
 import optparse
-from GTFFile import GTFIterator
-from GFFFile import ANNOTATION
+from .GTFFile import GTFIterator
+from .GFFFile import ANNOTATION
 
 def warning(msg):
     """


### PR DESCRIPTION
PR which fixes the relative imports for `gtf2bed` so that they work under Python 3.