### PR TITLE
Add automated testing for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 language: python
 python:
   - "2.7"
+  - "3.7"
 
 install:
   - "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "3.7"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
   - "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
   - "3.7"
 
 install:


### PR DESCRIPTION
PR which adds the following Python 3 versions to the set of Python versions that Travis-CI runs the automated tests for, as part of addressing issue #13:

- [x] Python 3.5
- [x] Python 3.6
- [x] Python 3.7
- [x] Python 3.8