### PR TITLE
gff_annotation_extractor: fix handling header for input & output files

### DIFF
--- a/GFFUtils/annotation.py
+++ b/GFFUtils/annotation.py
@@ -375,8 +375,17 @@ def annotate_feature_data(gff_lookup,feature_data_file,out_file):
             break
 
     # Read the feature data into a TabFile
-    input_data = TabFile(filen=feature_data_file,
-                         first_line_is_header=first_line_is_header)
+    try:
+        input_data = TabFile(filen=feature_data_file,
+                             first_line_is_header=first_line_is_header)
+    except IndexError as ex:
+        if first_line_is_header:
+            # Maybe first line was just a comment?
+            # Try again without header
+            input_data = TabFile(filen=feature_data_file)
+        else:
+            # Some other failure
+            raise ex
 
     # Initialise columns for output
     if input_data.header():

--- a/GFFUtils/annotation.py
+++ b/GFFUtils/annotation.py
@@ -364,10 +364,32 @@ def annotate_feature_data(gff_lookup,feature_data_file,out_file):
       feature_data_file  input data file with feature IDs in first column
       out_file           name of output file
     """
-    # Read the feature data into a TabFile
+    # Determine if input file has a header line
     print("Reading in data from %s" % feature_data_file)
-    feature_data = TabFile(filen=feature_data_file,
-                           first_line_is_header=True)
+    with open(feature_data_file,'rt') as fp:
+        for line in fp:
+            if line.startswith('#'):
+                first_line_is_header = True
+            else:
+                first_line_is_header = False
+            break
+
+    # Read the feature data into a TabFile
+    input_data = TabFile(filen=feature_data_file,
+                         first_line_is_header=first_line_is_header)
+
+    # Initialise columns for output
+    if input_data.header():
+        # Copy header
+        columns = [c for c in input_data.header()]
+    else:
+        # Make generic header
+        columns = ['data%d' % x for x in range(0,input_data.nColumns())]
+
+    # Create and populate second TabFile for output
+    feature_data = TabFile(column_names=columns)
+    for line in input_data:
+        feature_data.append(data=[x for x in line])
 
     # Append columns for annotation
     print("Appending columns for annotation")

--- a/GFFUtils/annotation.py
+++ b/GFFUtils/annotation.py
@@ -301,7 +301,7 @@ class HTSeqCountFile(object):
         # Total reads counted
         self.__total_reads = 0
         # Read in data from file
-        fp = open(htseqfile,'rU')
+        fp = open(htseqfile,'rt')
         # Flag indicating whether we're reading feature counts
         # or trailing totals
         reading_feature_counts = True

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -261,6 +261,10 @@ DDB0167147	8787
         self.feature_data_no_header = """DDB0166998	167
 DDB0167147	8787
 """
+        self.feature_data_bad_header = """#This is just a comment not a header
+DDB0166998	167
+DDB0167147	8787
+"""
         # Feature file path
         self.feature_data_file = os.path.join(self.wd,
                                              "features.txt")
@@ -300,6 +304,28 @@ DDB0167147	8787	DDB0167147	mRNA	DDB_G0275629	DDB_G0275629	DDB0232429	5954835	595
         # Make feature file
         with open(self.feature_data_file,'wt') as fp:
             fp.write(self.feature_data_no_header)
+        # Load GFF data
+        gff = GFFFile("test.gff",StringIO(gff_data))
+        lookup = GFFAnnotationLookup(gff)
+        # Do annotation
+        annotate_feature_data(lookup,
+                              self.feature_data_file,
+                              self.out_file)
+        # Check output
+        with open(self.out_file,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """data0	data1	exon_parent	feature_type_exon_parent	gene_ID	gene_name	chr	start	end	strand	gene_length	locus	description
+DDB0166998	167	DDB0166998	mRNA	DDB_G0276345	naa20	DDB0232429	6679320	6680012	+	692	DDB0232429:6679320-6680012	Description of gene naa20
+DDB0167147	8787	DDB0167147	mRNA	DDB_G0275629	DDB_G0275629	DDB0232429	5954835	5955486	+	651	DDB0232429:5954835-5955486	Description of gene DDB_G0275629
+""")
+
+    def test_annotate_feature_data_bad_header(self):
+        """
+        annotate_feature_data: annotates from GFF file (bad header)
+        """
+        # Make feature file
+        with open(self.feature_data_file,'wt') as fp:
+            fp.write(self.feature_data_bad_header)
         # Load GFF data
         gff = GFFFile("test.gff",StringIO(gff_data))
         lookup = GFFAnnotationLookup(gff)

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -254,15 +254,16 @@ class TestAnnotateFeatureData(unittest.TestCase):
         # Temporary directory
         self.wd = tempfile.mkdtemp()
         # Feature data fragment
-        self.feature_data = """#Gene
-DDB0166998
-DDB0167147
+        self.feature_data_with_header = """#Gene	Counts
+DDB0166998	167
+DDB0167147	8787
 """
-        # Write to temporary file
+        self.feature_data_no_header = """DDB0166998	167
+DDB0167147	8787
+"""
+        # Feature file path
         self.feature_data_file = os.path.join(self.wd,
                                              "features.txt")
-        with open(self.feature_data_file,'wt') as fp:
-            fp.write(self.feature_data)
         # Output file name
         self.out_file = os.path.join(self.wd,"out.txt")
 
@@ -270,10 +271,13 @@ DDB0167147
         if os.path.exists(self.wd):
             shutil.rmtree(self.wd)
 
-    def test_annotate_feature_data(self):
+    def test_annotate_feature_data_with_header(self):
         """
-        annotate_feature_data: annotates from GFF file
+        annotate_feature_data: annotates from GFF file (with header)
         """
+        # Make feature file
+        with open(self.feature_data_file,'wt') as fp:
+            fp.write(self.feature_data_with_header)
         # Load GFF data
         gff = GFFFile("test.gff",StringIO(gff_data))
         lookup = GFFAnnotationLookup(gff)
@@ -284,9 +288,31 @@ DDB0167147
         # Check output
         with open(self.out_file,'rt') as fp:
             self.assertEqual(fp.read(),
-                             """Gene	exon_parent	feature_type_exon_parent	gene_ID	gene_name	chr	start	end	strand	gene_length	locus	description
-DDB0166998	DDB0166998	mRNA	DDB_G0276345	naa20	DDB0232429	6679320	6680012	+	692	DDB0232429:6679320-6680012	Description of gene naa20
-DDB0167147	DDB0167147	mRNA	DDB_G0275629	DDB_G0275629	DDB0232429	5954835	5955486	+	651	DDB0232429:5954835-5955486	Description of gene DDB_G0275629
+                             """Gene	Counts	exon_parent	feature_type_exon_parent	gene_ID	gene_name	chr	start	end	strand	gene_length	locus	description
+DDB0166998	167	DDB0166998	mRNA	DDB_G0276345	naa20	DDB0232429	6679320	6680012	+	692	DDB0232429:6679320-6680012	Description of gene naa20
+DDB0167147	8787	DDB0167147	mRNA	DDB_G0275629	DDB_G0275629	DDB0232429	5954835	5955486	+	651	DDB0232429:5954835-5955486	Description of gene DDB_G0275629
+""")
+
+    def test_annotate_feature_data_no_header(self):
+        """
+        annotate_feature_data: annotates from GFF file (no header)
+        """
+        # Make feature file
+        with open(self.feature_data_file,'wt') as fp:
+            fp.write(self.feature_data_no_header)
+        # Load GFF data
+        gff = GFFFile("test.gff",StringIO(gff_data))
+        lookup = GFFAnnotationLookup(gff)
+        # Do annotation
+        annotate_feature_data(lookup,
+                              self.feature_data_file,
+                              self.out_file)
+        # Check output
+        with open(self.out_file,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """data0	data1	exon_parent	feature_type_exon_parent	gene_ID	gene_name	chr	start	end	strand	gene_length	locus	description
+DDB0166998	167	DDB0166998	mRNA	DDB_G0276345	naa20	DDB0232429	6679320	6680012	+	692	DDB0232429:6679320-6680012	Description of gene naa20
+DDB0167147	8787	DDB0167147	mRNA	DDB_G0275629	DDB_G0275629	DDB0232429	5954835	5955486	+	651	DDB0232429:5954835-5955486	Description of gene DDB_G0275629
 """)
 
 class TestAnnotateHtseqCountData(unittest.TestCase):


### PR DESCRIPTION
PR which aims to address issue #45 and better handle the presence or absence of header lines in the input feature data file, and work around issue https://github.com/fls-bioinformatics-core/genomics/issues/179 (in `bcftbx/TabFile`) when creating the header for the output annotated file.

This update assumes that if the first line of the input file starts with a comment character (`#`) then this is a header line, and copies the header across to the output. Otherwise a new set of generic column headers (`data0`, `data1` etc) are created.