### PR TITLE
gff_annotation_extractor: implement functionality for -t/--type option

### DIFF
--- a/GFFUtils/annotation.py
+++ b/GFFUtils/annotation.py
@@ -71,12 +71,10 @@ class GFFAnnotationLookup(object):
             if id_attr in line['attributes']:
                 # Check that the ID is unique
                 idx = line['attributes'][id_attr]
-                if idx in self.__lookup_id:
-                    logging.warning("Identifier '%s' is not unique: "
-                                    "feature '%s' already found" %
-                                    (id_attr,idx))
+                if idx not in self.__lookup_id:
+                    self.__lookup_id[idx] = []
                 # Store reference to data by ID
-                self.__lookup_id[idx] = line
+                self.__lookup_id[idx].append(line)
                 if parent_attr in line['attributes']:
                     # Store reference to parent by ID
                     parent = line['attributes'][parent_attr]
@@ -101,7 +99,7 @@ class GFFAnnotationLookup(object):
             if line['feature'] == 'gene':
                 if id_attr in line['attributes']:
                     idx = line['attributes'][id_attr]
-                    self.__lookup_id[idx] = line
+                    self.__lookup_id[idx] = [line]
                 else:
                     logging.warning("No '%s' attribute found on "
                                     "line %d: %s" % (id_attr,
@@ -115,8 +113,9 @@ class GFFAnnotationLookup(object):
           idx: ID attribute to search for
 
         Returns:
-          Line of data where the value of the ID attribute matches the
-          one supplied; raises KeyError exception if no match is found.
+          List of data lines where the value of the ID attribute matches
+          the one supplied; raises KeyError exception if no match is
+          found.
         """
         return self.__lookup_id[idx]
 
@@ -150,10 +149,10 @@ class GFFAnnotationLookup(object):
                 idx0 = self.getParentID(idx0)
         except KeyError as ex:
             if idx0 != idx:
-                # Check that it's a gene
-                data = self.getDataFromID(idx0)
-                assert(data['feature'] == 'gene')
-                return data
+                # Locate gene record in list
+                for data in self.getDataFromID(idx0):
+                    if data['feature'] == 'gene':
+                        return data
         return None
 
     def getAnnotation(self,idx):
@@ -169,10 +168,16 @@ class GFFAnnotationLookup(object):
         # Return annotation for an ID
         print("Collecting annotation for %s" % idx)
         # Parent feature data
+        parent_feature = None
         try:
-            parent_feature = self.getDataFromID(idx)
+            for data in self.getDataFromID(idx):
+                # Return the first feature
+                parent_feature = data
+                break
         except KeyError:
             # No parent data
+            pass
+        if not parent_feature:
             logging.warning("No parent data for feature '%s'" % idx)
             return GFFAnnotation(idx)
         # Parent gene data

--- a/GFFUtils/cli/gff_annotation_extractor.py
+++ b/GFFUtils/cli/gff_annotation_extractor.py
@@ -81,10 +81,13 @@ def main():
                    help="feature data to annotate")
     p.add_argument('-o',action="store",dest="out_file",default=None,
                    help="specify output file name")
-    p.add_argument('-t','--type',action="store",dest="feature_type",default='exon',
-                   help="feature type listed in input count files (default 'exon'; "
-                   "if used in conjunction with --htseq-count option then should be "
-                   "the same as that specified when running htseq-count)")
+    p.add_argument('-t','--type',action="store",dest="feature_type",
+                   default=None,
+                   help="restrict feature records to this type when "
+                   "matching features from input count files; if used in "
+                   "conjunction with --htseq-count option then should be "
+                   "the same as that specified when running htseq-count "
+                   "(default: include all feature records)")
     p.add_argument('-i','--id-attribute',action="store",dest="id_attribute",
                    default=None,
                    help="explicitly specify the name of the attribute to get the "
@@ -138,7 +141,9 @@ def main():
 
     # Build lookup
     print("Creating lookup for %s" % feature_format)
-    feature_lookup = GFFAnnotationLookup(gff,id_attr=args.id_attribute)
+    feature_lookup = GFFAnnotationLookup(gff,
+                                         id_attr=args.id_attribute,
+                                         feature_type=feature_type)
 
     # Annotate input data
     if htseq_count_mode:

--- a/GFFUtils/cli/gff_annotation_extractor.py
+++ b/GFFUtils/cli/gff_annotation_extractor.py
@@ -78,15 +78,17 @@ def main():
     p.add_argument('gff_file',metavar="GFF_FILE",
                    help="GFF or GTF file to get annotation data from")
     p.add_argument('feature_files',metavar="FEATURE_FILE",nargs="+",
-                   help="feature data to annotate")
+                   help="feature data to annotate; should be either "
+                   "tab-delimited data, or output from htseq-count (if "
+                   "--htseq-count is also specified)")
     p.add_argument('-o',action="store",dest="out_file",default=None,
                    help="specify output file name")
     p.add_argument('-t','--type',action="store",dest="feature_type",
                    default=None,
                    help="restrict feature records to this type when "
                    "matching features from input count files; if used in "
-                   "conjunction with --htseq-count option then should be "
-                   "the same as that specified when running htseq-count "
+                   "conjunction with --htseq-count then should be the "
+                   "same as that specified when running htseq-count "
                    "(default: include all feature records)")
     p.add_argument('-i','--id-attribute',action="store",dest="id_attribute",
                    default=None,

--- a/docs/gff_annotation_extractor.rst
+++ b/docs/gff_annotation_extractor.rst
@@ -10,19 +10,21 @@ it with data about each feature's parent gene from a GFF file.
 
 By default the program takes feature data from a single tab-delimited
 input file where the first column contains feature IDs, and outputs an
-updated copy of the file with data about the feature's parent gene
-appended to each line (chromosome, start and end positions, strand,
-etc).
+updated copy of the file with data about the feature's parent feature
+and parent gene appended to each line.
 
 In 'htseq-count' mode, one or more ``htseq-count`` output files should
 be provided as input; the program will write out the data about the
-feature's parent gene appended with the counts from each input file.
+feature's parent feature and parent gene appended with the counts from
+each input file.
 
 By default feature IDs from the feature data files are matched to
-exon records in the input GFF using the ``ID`` attribute in the
-record. The feature type to match against can be changed using the
-``-t`` option; the attribute used for the feature ID can be changed
-using the ``-i`` option.
+the first record in the input GFF where the ``ID`` attribute of that
+record is the same (a different attribute can be specified using the
+``-i`` option). All records are considered regardless of the feature
+type, unless the ``-t`` option is used to restrict the records to
+just those with the specified feature type (this may be required in
+'htseq-count' mode).
 
 The parent gene is located by recursively looking up records where
 the ``ID`` attribute matches the ``Parent`` attribute, until a
@@ -32,7 +34,8 @@ gene record is found.
 
    ``gff_annotation_extractor`` can also be used with GTF input,
    in which case the feature IDs are matched using the ``gene_id``
-   attribute by default.
+   attribute by default. Only ``gene`` feature types are considered
+   when using GTF data.
 
 Usage and options
 -----------------
@@ -65,10 +68,11 @@ Options:
 
 .. cmdoption:: -t FEATURE_TYPE, --type=FEATURE_TYPE
 
-   feature type listed in input count files (default
-   ``exon``; if used in conjunction with ``--htseq-count``
-   option then should be the same as that specified when
-   running htseq-count)
+   restrict feature records to this type when matching
+   features from input count files; if used in conjunction
+   with ``--htseq-count`` then should be the same as that
+   specified when running htseq-count (default: include all
+   feature records)
 
 .. cmdoption:: -i ID_ATTRIBUTE, --id-attribute=ID_ATTRIBUTE
 
@@ -142,14 +146,10 @@ The following is a non-exhaustive list of the warnings and errors
 that ``gff_annotation_extractor`` can produce, along with a brief
 description and possible cause:
 
-* ``No parent data for feature '...'``: indicates IDs in the feature
-  files for which no matching records can be located in the input GFF.
-  In this case the output annotation will be blank. Check that the
-  input feature file consists of tab-delimited data.
-
-* ``Identifier '...' is not unique: "feature '...' already found``:
-  indicates that multiple records exist in the GFF file which match
-  a feature ID from the feature file.
+* ``Unable to locate parent data for feature '...'``: indicates IDs
+  in the feature files for which no matching records can be located
+  in the input GFF. In this case the output annotation will be blank.
+  Check that the input feature file consists of tab-delimited data.
 
 * ``Multiple parents found on line ...``: indicates that a record
   matching a feature ID has a ``Parent`` attribute which contains

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -58,7 +58,9 @@ class TestGFFAnnotationLookup(unittest.TestCase):
         gff = GFFFile("test.gff",StringIO(gff_data))
         lookup = GFFAnnotationLookup(gff)
         # getDataFromID
-        self.assertEqual(str(lookup.getDataFromID("DDB_G0276345")),
+        data = lookup.getDataFromID("DDB_G0276345")
+        self.assertEqual(len(data),1)
+        self.assertEqual(str(data[0]),
                          str(GFFDataLine("DDB0232429	.	gene	6679320	6680012	.	+	.	ID=DDB_G0276345;Name=naa20;description=Description of gene naa20")))
         # getParentID
         self.assertEqual(lookup.getParentID("DDB0166998"),"DDB_G0276345")
@@ -87,7 +89,9 @@ class TestGFFAnnotationLookup(unittest.TestCase):
         gtf = GTFFile("test.gtf",StringIO(gtf_data))
         lookup = GFFAnnotationLookup(gtf)
         # getDataFromID
-        self.assertEqual(str(lookup.getDataFromID("ENSG00000223972.4")),
+        data = lookup.getDataFromID("ENSG00000223972.4")
+        self.assertEqual(len(data),1)
+        self.assertEqual(str(data[0]),
                          str(GTFDataLine("""chr1	HAVANA	gene	11869	14412	.	+	.	gene_id "ENSG00000223972.4"; transcript_id "ENSG00000223972.4"; gene_type "pseudogene"; gene_status "KNOWN"; gene_name "DDX11L1"; transcript_type "pseudogene"; transcript_status "KNOWN"; transcript_name "DDX11L1"; level 2; havana_gene "OTTHUMG00000000961.2";""")))
         # getParentID
         self.assertRaises(KeyError,


### PR DESCRIPTION
PR to address issue #44 by implementing functionality for the `-t` option of the `gff_annotation_extractor` utility (which previously did nothing).

In the updated code, if `-t` is not specified on the command line then the existing behaviour should be replicated (i.e. no filtering of feature records from the GFF based on feature type is performed when looking up IDs). If `-t` is specified then only records with the matching feature types will be considered when looking up IDs.